### PR TITLE
Fixed memory leak

### DIFF
--- a/optoctagons/opt_oct_hmat.c
+++ b/optoctagons/opt_oct_hmat.c
@@ -428,10 +428,12 @@ bool is_top_half(opt_oct_mat_t *oo, int dim){
 					else{
 						int ind = j1 + ((i1 + 1)*(i1 + 1))/2;
 						if(m[ind]!=INFINITY){
+                                                                      free(ca);
 							flag = false;
 							#if defined(TIMING)
 								record_timing(is_top_time);
 							#endif
+                                                                      
 							return false;
 						}
 					}

--- a/optoctagons/opt_oct_incr_closure_dense.c
+++ b/optoctagons/opt_oct_incr_closure_dense.c
@@ -369,6 +369,9 @@ bool incremental_closure_opt_dense(opt_oct_mat_t *oo, int dim, int v, bool is_in
 	else{
         	res = strengthning_dense(oo, temp1, n);
 	}
+
+          free (temp1);
+          free (temp2);
 	
 	return res;
 }


### PR DESCRIPTION
Before the fix crab-llvm could not analyze sv-benchmarks/c/ntdrivers/parport_true-unreach-call.i.cil.c with memory limit of 4GB so it seems an important memory leak.