### PR TITLE
fix for compiling client applications in C++

### DIFF
--- a/apron_interface/Makefile
+++ b/apron_interface/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.config
+
 INSTALL = install
 INSTALLd = install -d
 

--- a/elina_poly/opt_pk.h
+++ b/elina_poly/opt_pk.h
@@ -28,13 +28,14 @@
 #define __OPT_PK_H__
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "elina_int.h"
 #include "elina_rat.h"
 #include "comp_list.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined (HAS_APRON)
 #include "apron_wrapper.h"

--- a/ocaml_interface/Makefile
+++ b/ocaml_interface/Makefile
@@ -33,6 +33,13 @@ ICFLAGS += $(BASE_ICFLAGS) $(ML_ICFLAGS)
 LDFLAGS += $(BASE_LIFLAGS)
 CMXSINC = $(APRON_CMXSINC) -I .
 
+ICFLAGS += -I ../partitions_api -I ../elina_linearize -I ../elina_auxiliary -I ../elina_poly -I ../elina_oct
+
+LDFLAGS += -L../partitions_api -L../elina_linearize  -L../elina_auxiliary -L../elina_poly -L../elina_oct -L.
+
+LDFLAGS +=  -R../partitions_api -R../elina_linearize  -R../elina_auxiliary -R../elina_poly  -cclib -R../elina_oct -R.
+
+
 APRON_CAML_INCLUDE = $(shell $(OCAMLFIND) query apron)
 
 
@@ -59,7 +66,7 @@ LIBS = -lapron -lmpfr -lgmp -lm
 # Rules
 #---------------------------------------
 
-all: ml mlexample.byte
+all: ml mlexample.byte mlexample.opt
 
 ml: elina_poly.mli elina_poly.ml elina_poly.cmi mllib 
 
@@ -75,6 +82,9 @@ endif
 
 mlexample.byte: mlexample.ml elina_poly.cma
 	$(OCAMLC) $(OCAMLFLAGS) -I $(MLGMPIDL_LIB) -I $(APRON_CAML_INCLUDE) -o $@ bigarray.cma gmp.cma apron.cma elina_poly.cma $<
+
+mlexample.opt: mlexample.ml elina_poly.cmxa
+	$(OCAMLOPT) $(OCAMLFLAGS) -I $(MLGMPIDL_LIB) -I $(APRON_CAML_INCLUDE) -o $@ bigarray.cmxa gmp.cmxa apron.cmxa elina_poly.cmxa $<
 
 clean:
 	/bin/rm -f *.[ao] *.so


### PR DESCRIPTION
The header file did not work if included from C++ because it indirectly included <gmp.h> from inside an extern "C" block and this does not work at least on my distribution.

I thus moved the #include out of the extern "C".