### PR TITLE
Bugfix in configure

### DIFF
--- a/configure
+++ b/configure
@@ -384,7 +384,7 @@ then
 fi
 
 # Set apron source root
-if test "x$apron_srcroot" == "x"; then
+if test "x$apron_srcroot" = "x"; then
     if test $use_opam -eq 1; then
 	apron_srcroot=`ocamlfind query apron`
     else

--- a/opam
+++ b/opam
@@ -1,8 +1,9 @@
-opam-version: "1.2.2"
+opam-version: "1.2"
 authors: ["Gagandeep Singh" "Markus Püschel" "Martin Vechev"]
 homepage: "http://elina.ethz.ch/"
 maintainer: "Gagandeep Singh <gsingh@inf.ethz.ch>"
-bug-reports: "https://github.com/eth-srl/ELINA"
+dev-repo: "https://github.com/eth-srl/ELINA.git"
+bug-reports: "https://github.com/eth-srl/ELINA/issues"
 version: "1.0"
 license: "LGPL-3"
 build: [


### PR DESCRIPTION
Hi Gagan,

I found CI fails in ocaml/opam-repository/pull/11815 was due to a bug in the `configure`.

Could you update `elina-1.0.tar.gz` to include this fix, so I can try sending a PR to opam-repository again? I am sorry for the inconvenience. It's my bad. 😢 

Sincerely,
Sungkeun